### PR TITLE
mac patch

### DIFF
--- a/src/mcedit2/util/directories.py
+++ b/src/mcedit2/util/directories.py
@@ -1,7 +1,12 @@
 import os
 import sys
-import win32api
-
+try:
+    assert sys.platform == "win32"
+    # If sys.platform is "win32", win32api is needed and expected
+    import win32api
+except AssertionError as _ae:
+    # If sys.platform is not "win32", do not try to import win32api
+    win32api = None
 
 def getUserFilesDirectory():
     if sys.platform == "win32":

--- a/src/mcedit2/util/qglcontext.py
+++ b/src/mcedit2/util/qglcontext.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from OpenGL import GL
 from PySide import QtOpenGL, QtGui
 import logging
+from sys import platform
 
 log = logging.getLogger(__name__)
 
@@ -36,6 +37,16 @@ def validateQGLContext(context):
 
     actualFormat = context.format()
     """:type : QtOpenGL.QGLFormat"""
+
+    def getmajor():
+        return int(str(GL.glGetString(GL.GL_VERSION)).split()[0].partition(".")[0])
+
+    def getminor():
+        return int(str(GL.glGetString(GL.GL_VERSION)).split()[0].partition(".")[2])
+
+    if platform == 'darwin':
+        actualFormat.majorVersion = getmajor
+        actualFormat.minorVersion = getminor
 
     detailedText = "Obtained a GL context with this format:\n"
     detailedText += "Valid: %s\n" % (context.isValid(),)


### PR DESCRIPTION
patches Intel HD Graphics 5000 (OS X 10.10.3) issue where OpenGL
version 2.4 is parsed as 1.0

makes win32api only import if platform is win32 (other platforms don’t
have it and won’t use it)