### PR TITLE
Fix getUserFilesDirectory to avoid accessing root privileges in linux

### DIFF
--- a/src/mcedit2/panels/player.py
+++ b/src/mcedit2/panels/player.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
 import uuid
+import os
 
 from PySide import QtGui
 from PySide.QtCore import Qt
@@ -143,7 +144,7 @@ class PlayerPanel(QtGui.QWidget):
 
     def updateNBTTree(self):
         self.nbtEditor.undoCommandPrefixText = ("Player %s: " % self.selectedUUID) if self.selectedUUID else "Single-player: "
-        self.nbtEditor.setRootTagRef(self.selectedPlayer)
+        self.nbtEditor.setRootTagRef(self.selectedPlayer, os.name == 'posix')   # Workround for bug 53
 
     def updateInventory(self):
         self.inventoryEditor.editorSession = self.editorSession

--- a/src/mcedit2/panels/worldinfo.py
+++ b/src/mcedit2/panels/worldinfo.py
@@ -3,6 +3,7 @@
 """
 from __future__ import absolute_import
 import logging
+import os
 from contextlib import contextmanager
 
 from PySide import QtGui
@@ -140,7 +141,7 @@ class WorldInfoPanel(QtGui.QWidget):
 
     def updateNBTTree(self):
         self.worldNBTEditor.undoCommandPrefixText = self.tr('World Metadata: ')
-        self.worldNBTEditor.setRootTagRef(self.worldMeta)
+        self.worldNBTEditor.setRootTagRef(self.worldMeta, os.name == 'posix')   # Workround for bug 53
 
     def revisionDidChange(self):
         self.worldMeta = self.editorSession.worldEditor.adapter.metadata

--- a/src/mcedit2/util/directories.py
+++ b/src/mcedit2/util/directories.py
@@ -9,26 +9,29 @@ def getUserFilesDirectory():
         # It cannot represent all possible filenames, so get the exe filename
         # using this wide-character API, which returns a `unicode`
         exe = win32api.GetModuleFileNameW(None)
+        user_data_dir = "MCEdit User Data"
     else:
         # On OS X, the FS encoding is always UTF-8
         # OS X filenames are defined to be UTF-8 encoded.
         # On Linux, the FS encoding is given by the current locale
         # Linux filenames are defined to be bytestrings.
         exe = sys.executable.decode(sys.getfilesystemencoding())
+        user_data_dir = ".mcedit"
 
     assert os.path.exists(exe), "%r does not exist" % exe
     if hasattr(sys, 'frozen'):
         folder = os.path.dirname(exe)
     else:
-        if exe.endswith("python") or exe.endswith("python.exe"):
+        if exe.endswith("python") or exe.endswith("python2.7") or exe.endswith("python.exe"):
             script = sys.argv[0]
             # assert the source checkout is not in a non-representable path...
             assert os.path.exists(script), "Source checkout path cannot be represented with 'mbcs' encoding. Put the source checkout somewhere else."
-            folder = os.path.dirname(os.path.dirname(os.path.dirname(script)))  # from src/mcedit, ../../
+            #folder = os.path.dirname(os.path.dirname(os.path.dirname(script)))  # from src/mcedit, ../../
+            folder = os.path.expanduser("~")
         else:
             folder = os.path.dirname(exe)
 
-    dataDir = os.path.join(folder, "MCEdit User Data")
+    dataDir = os.path.join(folder, user_data_dir)
 
     if not os.path.exists(dataDir):
         os.makedirs(dataDir)


### PR DESCRIPTION
Currently, running mcedit2 in linux will attempt to create a folder "MCEdit User Data" under where python executable is, most apparently '/usr/bin/MCEdit User Data'. This will not only force the user to run as root, but also obeys the file system conventions on linux. This fix will try to locate the user data folder at home directory like '/home/xxx/.mcedit'.

Also, I think this statement `if exe.endswith("python") or exe.endswith("python.exe"):` is not proper enough, as it may also cause some strange problems on linux. I'm not sure how should I modify it so I just made a work around of my own.

Thank you!