### PR TITLE
Update storage to user's home directory

### DIFF
--- a/src/mcedit2/util/directories/posix.py
+++ b/src/mcedit2/util/directories/posix.py
@@ -30,7 +30,8 @@ def getUserFilesDirectory():
             sys.argv[0], sys.getfilesystemencoding()))
         raise
 
-    folder = os.path.dirname(os.path.dirname(os.path.dirname(script)))  # main script is src/mcedit/main.py, so, ../../
+    #folder = os.path.dirname(os.path.dirname(os.path.dirname(script))) - On Linux, this makes MCE2 try to write to /usr/
+    folder = os.path.expanduser('~') # The Cross-Platform way to find the user's $HOME directory
     dataDir = os.path.join(folder, "MCEdit User Data")
 
     if not os.path.exists(dataDir):


### PR DESCRIPTION
`os.path.expanduser(path)`:

On Unix and Windows, return the argument with an initial component of `~` or `~user` replaced by that user‘s home directory.

On Unix, an initial `~` is replaced by the environment variable `HOME` if it is set; otherwise the current user’s home directory is looked up in the password directory through the built-in module `pwd`. An initial `~user` is looked up directly in the password directory.

On Windows, `HOME` and `USERPROFILE` will be used if set, otherwise a combination of `HOMEPATH` and `HOMEDRIVE` will be used. An initial `~user` is handled by stripping the last directory component from the created user path derived above.

It should also be noted that if the user is logged on to a domain on Windows and has their profile home folder set in Active Directory, then this will report that mapped network folder instead of the local home directory.

Source: https://docs.python.org/2/library/os.path.html#os.path.expanduser