### PR TITLE
Added method to redraw a EditorTool's toolWidget

### DIFF
--- a/src/mcedit2/editorsession.py
+++ b/src/mcedit2/editorsession.py
@@ -1348,6 +1348,17 @@ class EditorTab(QtGui.QWidget):
         if view is not None:
             self.editorSession.loader.addClient(view)
 
+    def redrawWidget(self, tool):
+        '''
+        Primarily for plugin use. Access via 'editorSession.editorTab.redrawWidget()'
+        :param widget: EditorTool
+        '''
+        if tool.toolWidget:
+            self.toolOptionsArea.takeWidget()
+            self.toolOptionsArea.setWidget(tool.toolWidget)
+            self.toolOptionsArea.update()
+            self.toolOptionsArea.repaint()
+            self.toolOptionsArea.show()
 
     def toolDidChange(self, tool):
         if tool.toolWidget:


### PR DESCRIPTION
This allows for EditorTools to change/redraw their widget's based if they need to show more options due to a previous option being selected/deselected. The extra update/repaint/show methods are probably overkill, but I don't know which one should be used for this.