### PR TITLE
Allow read-only use of mceditlib in python3

### DIFF
--- a/setup_mceditlib.py
+++ b/setup_mceditlib.py
@@ -23,7 +23,9 @@ include_dirs = [numpy.get_include()]
 mceditlib_ext_modules = cythonize([
     "src/mceditlib/nbt.pyx",
     "src/mceditlib/relight/with_cython.pyx"
-])
+],
+    compile_time_env={'IS_PY2': True},
+    )
 
 for m in mceditlib_ext_modules:
     m.include_dirs = include_dirs

--- a/setup_mceditlib.py
+++ b/setup_mceditlib.py
@@ -10,6 +10,7 @@ import Cython.Compiler.Options
 Cython.Compiler.Options.annotate = True
 
 import numpy
+import sys
 
 with open("version.txt") as f:
     version = f.read().strip()
@@ -24,7 +25,7 @@ mceditlib_ext_modules = cythonize([
     "src/mceditlib/nbt.pyx",
     "src/mceditlib/relight/with_cython.pyx"
 ],
-    compile_time_env={'IS_PY2': True},
+    compile_time_env={'IS_PY2': sys.version_info[0] < 3},
     )
 
 for m in mceditlib_ext_modules:
@@ -50,10 +51,12 @@ setup(name='mceditlib',
       url='https://github.com/mcedit/mcedit2',
       license='MIT License',
       packages=find_packages('src', include=["mceditlib*"]),
+      package_data={'mceditlib': ['blocktypes/*.json', 'anvil/biomes.csv']},
       package_dir={'': 'src'},
       ext_modules=mceditlib_ext_modules,
       include_dirs=include_dirs,
       include_package_data=True,
       zip_safe=False,
       install_requires=install_requires,
+      use_2to3=True,
       )

--- a/setup_mceditlib.py
+++ b/setup_mceditlib.py
@@ -11,7 +11,7 @@ Cython.Compiler.Options.annotate = True
 
 import numpy
 
-with file("version.txt") as f:
+with open("version.txt") as f:
     version = f.read().strip()
 
 install_requires = [

--- a/src/mceditlib/anvil/adapter.py
+++ b/src/mceditlib/anvil/adapter.py
@@ -780,7 +780,7 @@ class AnvilWorldAdapter(object):
         """
         lockfile = self.revisionHistory.rootFolder.getFilePath("session.lock")
         self.lockTime = int(time.time() * 1000)
-        with file(lockfile, "wb") as f:
+        with open(lockfile, "wb") as f:
             f.write(struct.pack(">q", self.lockTime))
             f.flush()
             os.fsync(f.fileno())
@@ -798,7 +798,7 @@ class AnvilWorldAdapter(object):
 
         lockfile = self.revisionHistory.rootFolder.getFilePath("session.lock")
         try:
-            (lock, ) = struct.unpack(">q", file(lockfile, "rb").read())
+            (lock, ) = struct.unpack(">q", open(lockfile, "rb").read())
         except struct.error:
             lock = -1
         if lock != self.lockTime:

--- a/src/mceditlib/anvil/worldfolder.py
+++ b/src/mceditlib/anvil/worldfolder.py
@@ -63,7 +63,7 @@ class AnvilWorldFolder(object):
         return os.unlink(self.getFilePath(path))
 
     def readFile(self, path):
-        with file(self.getFilePath(path), "rb") as f:
+        with open(self.getFilePath(path), "rb") as f:
             return f.read()
 
     def writeFile(self, path, data):
@@ -71,7 +71,7 @@ class AnvilWorldFolder(object):
         dirpath = os.path.dirname(path)
         if not os.path.exists(dirpath):
             os.makedirs(dirpath)
-        with file(path, "wb") as f:
+        with open(path, "wb") as f:
             f.write(data)
 
     def listFolder(self, path):

--- a/src/mceditlib/blocktypes/json_resources.py
+++ b/src/mceditlib/blocktypes/json_resources.py
@@ -23,7 +23,7 @@ def openResource(filename):
             log.exception("pkg_resources not available")
             raise
 
-    return file(path)
+    return open(path)
 
 def getJsonFile(filename):
     if filename in _cachedJsons:

--- a/src/mceditlib/findadapter.py
+++ b/src/mceditlib/findadapter.py
@@ -79,7 +79,7 @@ def isLevel(cls, filename):
         return cls.canOpenFile(filename)
 
     if os.path.isfile(filename):
-        with file(filename, "rb") as f:
+        with open(filename, "rb") as f:
             data = f.read()
 
         if hasattr(cls, "_isDataLevel"):

--- a/src/mceditlib/java.py
+++ b/src/mceditlib/java.py
@@ -87,7 +87,7 @@ class JavaLevel(FakeChunkedLevelAdapter):
             gz = gzip.GzipFile(filename)
             strdata = gz.read()
         except Exception:
-            strdata = file(filename, "rb").read()
+            strdata = open(filename, "rb").read()
 
         data = fromstring(strdata, dtype='uint8')
 

--- a/src/mceditlib/minecraft_server.py
+++ b/src/mceditlib/minecraft_server.py
@@ -85,7 +85,7 @@ class ServerJarStorage(object):
             os.makedirs(self.cacheDir)
         readme = os.path.join(self.cacheDir, "README.TXT")
         if not os.path.exists(readme):
-            with file(readme, "w") as f:
+            with open(readme, "w") as f:
                 f.write("""
 About this folder:
 
@@ -163,7 +163,7 @@ this way.
 
     def checksumForVersion(self, v):
         jf = self.jarfileForVersion(v)
-        with file(jf, "rb") as f:
+        with open(jf, "rb") as f:
             import hashlib
             return hashlib.md5(f.read()).hexdigest()
 
@@ -198,14 +198,14 @@ def readProperties(filename):
     if not os.path.exists(filename):
         return {}
 
-    with file(filename) as f:
+    with open(filename) as f:
         properties = dict((line.split("=", 2) for line in (l.strip() for l in f) if not line.startswith("#")))
 
     return properties
 
 
 def saveProperties(filename, properties):
-    with file(filename, "w") as f:
+    with open(filename, "w") as f:
         for k, v in properties.iteritems():
             f.write("{0}={1}\n".format(k, v))
 
@@ -304,7 +304,7 @@ class MCServerChunkGenerator(object):
         readme = os.path.join(self.worldCacheDir, "README.TXT")
 
         if not os.path.exists(readme):
-            with file(readme, "w") as f:
+            with open(readme, "w") as f:
                 f.write("""
     About this folder:
 

--- a/src/mceditlib/pc/regionfile.py
+++ b/src/mceditlib/pc/regionfile.py
@@ -49,12 +49,12 @@ class RegionFile(object):
         if not os.path.exists(path):
             if readonly:
                 raise IOError("Region file not found: %r" % path)
-            file(path, "w").close()
+            open(path, "w").close()
             newFile = True
 
         filesize = os.path.getsize(path)
         mode = "rb" if readonly else "rb+"
-        with file(self.path, mode) as f:
+        with open(self.path, mode) as f:
 
             if newFile:
                 filesize = self.SECTOR_BYTES * 2
@@ -208,7 +208,7 @@ class RegionFile(object):
         if sectorStart + numSectors > len(self.freeSectors):
             raise ChunkNotPresent((cx, cz))
 
-        with file(self.path, "rb") as f:
+        with open(self.path, "rb") as f:
             f.seek(sectorStart * self.SECTOR_BYTES)
             data = f.read(numSectors * self.SECTOR_BYTES)
         if len(data) < 5:
@@ -301,7 +301,7 @@ class RegionFile(object):
 
                 region_debug("REGION SAVE {0},{1}, growing by {2}b".format(cx, cz, len(data)))
 
-                with file(self.path, "rb+") as f:
+                with open(self.path, "rb+") as f:
                     f.seek(0, 2)
                     filesize = f.tell()
 
@@ -320,7 +320,7 @@ class RegionFile(object):
         self.setTimestamp(cx, cz)
 
     def writeSector(self, sectorNumber, data, format):
-        with file(self.path, "rb+") as f:
+        with open(self.path, "rb+") as f:
             region_debug("REGION: Writing sector {0}".format(sectorNumber))
 
             f.seek(sectorNumber * self.SECTOR_BYTES)
@@ -341,7 +341,7 @@ class RegionFile(object):
         cx &= 0x1f
         cz &= 0x1f
         self.offsets[cx + cz * 32] = offset
-        with file(self.path, "rb+") as f:
+        with open(self.path, "rb+") as f:
             f.seek(0)
             f.write(self.offsets.tostring())
 
@@ -366,8 +366,6 @@ class RegionFile(object):
         cx &= 0x1f
         cz &= 0x1f
         self.modTimes[cx + cz * 32] = timestamp
-        with file(self.path, "rb+") as f:
+        with open(self.path, "rb+") as f:
             f.seek(self.SECTOR_BYTES)
             f.write(self.modTimes.tostring())
-
-

--- a/src/mceditlib/pc/regionfile.py
+++ b/src/mceditlib/pc/regionfile.py
@@ -4,7 +4,7 @@
     Reads and writes chunks to *.mcr* (Minecraft Region)
     and *.mca* (Minecraft Anvil Region) files
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 import logging
 import os
 import struct
@@ -59,8 +59,8 @@ class RegionFile(object):
             if newFile:
                 filesize = self.SECTOR_BYTES * 2
                 f.truncate(filesize)
-                self.offsets = numpy.zeros(self.SECTOR_BYTES/4, dtype='>u4')
-                self.modTimes = numpy.zeros(self.SECTOR_BYTES/4, dtype='>u4')
+                self.offsets = numpy.zeros(self.SECTOR_BYTES//4, dtype='>u4')
+                self.modTimes = numpy.zeros(self.SECTOR_BYTES//4, dtype='>u4')
             else:
 
                 if not readonly:
@@ -81,7 +81,7 @@ class RegionFile(object):
                 self.offsets = numpy.fromstring(offsetsData, dtype='>u4')
                 self.modTimes = numpy.fromstring(modTimesData, dtype='>u4')
 
-            self.freeSectors = [True] * (filesize / self.SECTOR_BYTES)
+            self.freeSectors = [True] * (filesize // self.SECTOR_BYTES)
             self.freeSectors[0:2] = False, False
 
             if not newFile:
@@ -251,7 +251,7 @@ class RegionFile(object):
         offset = self._getOffset(cx, cz)
         sectorNumber = offset >> 8
         sectorsAllocated = offset & 0xff
-        sectorsNeeded = (len(data) + self.CHUNK_HEADER_SIZE) / self.SECTOR_BYTES + 1
+        sectorsNeeded = (len(data) + self.CHUNK_HEADER_SIZE) // self.SECTOR_BYTES + 1
         if sectorsNeeded >= 256:
             err = RegionFormatError("Cannot save chunk %s with compressed length %s (exceeds 1 megabyte)" %
                                     ((cx, cz), len(data)))

--- a/src/mceditlib/pocket.py
+++ b/src/mceditlib/pocket.py
@@ -30,7 +30,7 @@ class PocketChunksFile(object):
 
     @property
     def file(self):
-        openfile = lambda: file(self.path, "rb+")
+        openfile = lambda: open(self.path, "rb+")
         if PocketChunksFile.holdFileOpen:
             if self._file is None:
                 self._file = openfile()
@@ -47,7 +47,7 @@ class PocketChunksFile(object):
         self.path = path
         self._file = None
         if not os.path.exists(path):
-            file(path, "w").close()
+            open(path, "w").close()
 
         with self.file as f:
 

--- a/src/mceditlib/revisionhistory.py
+++ b/src/mceditlib/revisionhistory.py
@@ -656,7 +656,7 @@ class RevisionHistoryNode(object):
         if self.worldFolder.containsChunk(cx, cz, dimName):
             self.worldFolder.deleteChunk(cx, cz, dimName)
         else:
-            with file(self._deadChunksFile(), "w") as f:
+            with open(self._deadChunksFile(), "w") as f:
                 f.write("%d, %d, %s\n" % (cx, cz, dimName))
                 f.close()
             self.deadChunks.add((cx, cz, dimName))
@@ -669,7 +669,7 @@ class RevisionHistoryNode(object):
         """
         if self.invalid:
             raise RuntimeError("Accessing invalid node: %r" % self)
-        with file(self._deadChunksFile()) as f:
+        with open(self._deadChunksFile()) as f:
             lines = f.read().split('\n')
 
         def _coords():
@@ -733,7 +733,7 @@ class RevisionHistoryNode(object):
         if self.worldFolder.containsFile(path):
             self.worldFolder.deleteFile(path)
         else:
-            with file(self._deadFilesFile(), "w") as f:
+            with open(self._deadFilesFile(), "w") as f:
                 f.write("%s\n" % path)
                 f.close()
             self.deadFiles.add(path)
@@ -746,7 +746,7 @@ class RevisionHistoryNode(object):
         """
         if self.invalid:
             raise RuntimeError("Accessing invalid node: %r" % self)
-        with file(self._deadFilesFile()) as f:
+        with open(self._deadFilesFile()) as f:
             return f.read().split('\n')
 
     def readFile(self, path):

--- a/src/mceditlib/selection/__init__.py
+++ b/src/mceditlib/selection/__init__.py
@@ -23,12 +23,13 @@ class ISelection(object):
     """
     chunkPositions = NotImplemented
 
-    def __contains__(self, (x, y, z)):
+    def __contains__(self, xyz):
         """
         Return True if the given set of coordinates is within this selection.
 
         :rtype: bool
         """
+        (x, y, z) = xyz
 
     def contains_coords(self, x, y, z):
         """
@@ -544,7 +545,8 @@ class BoundingBox(SelectionBox):
         # return self.__class__(origin, size)
         return BoundingBox(origin, size)
 
-    def __contains__(self, (x, y, z)):
+    def __contains__(self, xyz):
+        (x, y, z) = xyz
         if x < self.minx or x >= self.maxx:
             return False
         if y < self.miny or y >= self.maxy:


### PR DESCRIPTION
Thank you for developing this software!

I've recently had great success using mceditlib to read minecraft maps for a project I'm working on. In the process I made some changes so that the code can run on python 3. I've posted them on my own github, but I'm also wondering if there's any upstream interest in maintaining some python 3 compatibility.

I found mceditlib extremely useful as a standalone component: to the best of my knowledge it's the most feature-complete Python library for reading minecraft maps. I think this patchset is able to expand its reach without imposing too much of a maintainability burden.

The general approach here is to have setuptools automatically run 2to3 on the code if mceditlib is being installed in a python 3 environment. This requires making only a few changes so that the automatic conversion doesn't get tripped up. (I don't have a copy of python2 to regression-test these changes, but I think they should have minimal impact on mcedit itself.)

As a brief summary:
* This project uses the `file` constructor to open files rather than `open`. This is unsupported in python3, and not that common in python2 either, so 2to3 can't convert this automatically. Manually changing uses of `file` to `open` makes up a majority of the diff here.
* `nbt.pyx` is Cython code, which needs some special treatment. So far I've figured out how to read NBT files in python3, and left writing them as a TODO.
* A few more misc changes that 2to3 can't make automatically
* Support for transparently calling 2to3 in `setup_mceditlib.py`


Let me know if there's any interest in this code!