### PR TITLE
Fix AttributeError when Qt4 is built without Qt3 support

### DIFF
--- a/src/mcedit2/dialogs/configure_blocks.py
+++ b/src/mcedit2/dialogs/configure_blocks.py
@@ -273,7 +273,7 @@ class ConfigureBlocksDialog(QtGui.QDialog, Ui_configureBlocks):
 
         self.blocksView.clicked.connect(self.currentBlockClicked)
 
-        self.internalNameBox.textChanged.connect(self.nameTextChanged)
+        self.internalNameBox.editTextChanged.connect(self.nameTextChanged)
 
         self.addBlockButton.clicked.connect(self.addBlock)
         self.removeBlockButton.clicked.connect(self.removeBlock)


### PR DESCRIPTION
As per the documentation at http://pyside.github.io/docs/pyside/PySide/QtGui/QComboBox.html, the correct name for the signal is `editTextChanged`, not `textChanged`.