### PR TITLE
Restrict cython to <0.28 because of compatibility breaking changes

### DIFF
--- a/requirements-mceditlib.txt
+++ b/requirements-mceditlib.txt
@@ -1,3 +1,3 @@
-cython
+cython<0.28
 numpy
 arrow


### PR DESCRIPTION
cython 0.28 broke backwards compatibility (See https://github.com/cython/cython/commit/0961b9a758592b667495e9155267c6b337b8b214).

mceditlib/relight/with_cython.pyx won't build with it and probably needs a major rewrite in order to use a more recent cython version.

Fixes issue  #397 