### PR TITLE
use virtualenv's python and pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ As a bonus, you can use the `-debug` flag to enable the Debug menu and a few ext
     cd (Your mcedit2 location)
     virtualenv ENV
     . ENV/bin/activate
-    pip install -r requirements.txt
-    python setup.py develop
+    ENV/bin/pip install -r requirements.txt
+    ENV/bin/python setup.py develop
     mcedit2
 
 If your distro packages python3 as the default version of python instead of python2, you will probably want to set your virtualenv to use python2, i.e.


### PR DESCRIPTION
$ pip --version
pip 18.0 from /usr/lib/python3.7/site-packages/pip (python 3.7)

$ ENV/bin/pip --version
pip 18.0 from /home/user5145/test/ENV/lib/python2.7/site-packages/pip (python 2.7)

It should be the same.
If you ship virtualenv then it seems logic to me that you want to use provided by it pip and python. I'm not familiar with this project and don't develop in python so i may be wrong, but i tried port it to flatpak.
It removes some errors and doesnt try to install to /usr.